### PR TITLE
Make `WorkerPool` public (again)

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/netty3/package.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/netty3/package.scala
@@ -33,5 +33,5 @@ package object netty3 {
     Executors.newCachedThreadPool(threadFactory)
   }
 
-  private[netty3] val WorkerPool: NioWorkerPool = new NioWorkerPool(Executor, numWorkers())
+  val WorkerPool: NioWorkerPool = new NioWorkerPool(Executor, numWorkers())
 }


### PR DESCRIPTION
Problem

There is an infamous epoll bug in Netty (https://github.com/netty/netty/issues/663), causing a service not serving any requests eats 100% CPU. Worker pools provide a method, namely `rebuildSelectors`, to work around this problem. This method needs to be invoked periodically.  `WorkerPool` being package private makes calling this method on the default worker pool impossible, it would be handy if `WorkerPool` is public, so that the method is easily available.

Solution

Make `WorkerPool` public again.